### PR TITLE
defined KEYMAP_GRID for grid layouts

### DIFF
--- a/keyboard/planck/keymap_common.h
+++ b/keyboard/planck/keymap_common.h
@@ -34,9 +34,7 @@ extern const uint8_t keymaps[][MATRIX_ROWS][MATRIX_COLS];
 extern const uint16_t fn_actions[];
 
 
-/* GH60 keymap definition macro
- * K2C, K31 and  K3C are extra keys for ISO
- */
+// MIT Layout
 #define KEYMAP( \
     K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, \
     K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, \
@@ -48,5 +46,19 @@ extern const uint16_t fn_actions[];
     { KC_##K20, KC_##K21, KC_##K22, KC_##K23, KC_##K24, KC_##K25, KC_##K26, KC_##K27, KC_##K28, KC_##K29, KC_##K2A, KC_##K2B }, \
     { KC_##K30, KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_##K35, KC_NO,    KC_##K37, KC_##K38, KC_##K39, KC_##K3A, KC_##K3B }  \
 }
+
+// Grid Layout
+#define KEYMAP_GRID( \
+    K00, K01, K02, K03, K04, K05, K06, K07, K08, K09, K0A, K0B, \
+    K10, K11, K12, K13, K14, K15, K16, K17, K18, K19, K1A, K1B, \
+    K20, K21, K22, K23, K24, K25, K26, K27, K28, K29, K2A, K2B, \
+    K30, K31, K32, K33, K34, K35, K36, K37, K38, K39, K3A, K3B  \
+) { \
+    { KC_##K00, KC_##K01, KC_##K02, KC_##K03, KC_##K04, KC_##K05, KC_##K06, KC_##K07, KC_##K08, KC_##K09, KC_##K0A, KC_##K0B }, \
+    { KC_##K10, KC_##K11, KC_##K12, KC_##K13, KC_##K14, KC_##K15, KC_##K16, KC_##K17, KC_##K18, KC_##K19, KC_##K1A, KC_##K1B }, \
+    { KC_##K20, KC_##K21, KC_##K22, KC_##K23, KC_##K24, KC_##K25, KC_##K26, KC_##K27, KC_##K28, KC_##K29, KC_##K2A, KC_##K2B }, \
+    { KC_##K30, KC_##K31, KC_##K32, KC_##K33, KC_##K34, KC_##K35, KC_##K36, KC_##K37, KC_##K38, KC_##K39, KC_##K3A, KC_##K3B }  \
+}
+
 
 #endif

--- a/keyboard/planck/keymap_matthew.c
+++ b/keyboard/planck/keymap_matthew.c
@@ -1,25 +1,45 @@
 // by Matthew Pepers - https://github.com/pepers
 
+/* grid planck layout - modified programmer dvorak
+,-----------------------------------------------------------------------------------------------.
+| pause |   @   |   |   |   ^   |       |       |       |       |   *   |   #   |   $   |  del  |
+|  esc  |  ; :  |  , <  |  . >  |   P   |   Y   |   F   |   G   |   G   |   C   |   R   | bkspc |
+|  F1   |  F2   |  F3   |  F4   |  F5   |  F6   |  F7   |  F8   |  F9   |  F10  |  F11  |  F12  |
+|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
+|   &   |   /   |   {   |   (   |   [   |   =   |   !   |   ]   |   )   |   }   |   \   |   +   |
+|  ` ~  |   A   |   O   |   E   |   U   |   I   |   D   |   H   |   T   |   N   |   S   |  - _  |
+|   %   |   7   |   5   |   3   |   1   |   9   |   0   |   2   |   4   |   6   |   8   |   ?   |
+|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
+|       |       |       |       |       |       |       |       |       |       |       | prtsc |
+|  tab  |  ' "  |   Q   |   J   |   K   |   X   |   B   |   M   |   W   |   V   |   Z   | retrn |
+|       |       |       |       |       |       |       |       |       |       |       | insrt |
+|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
+|       |       |       |       |       |       |       |       |       |       |       |       |
+| lctrl | lgui  | lalt  | ralt  | lower | shift | space | raise | left  | down  |  up   | right |
+|       |       |       |       |       |       |       |       | home  | pgdn  | pgup  |  end  |
+`-----------------------------------------------------------------------------------------------'
+*/
+
 #include "keymap_common.h"
 
 const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   /* 0: dvorak */
-  [0] = KEYMAP( ESC, SCLN, COMM,  DOT,    P,    Y,    F,    G,    C,    R,    L, BSPC,   \
-                GRV,    A,    O,    E,    U,    I,    D,    H,    T,    N,    S, MINS,   \
-                TAB, QUOT,    Q,    J,    K,    X,    B,    M,    W,    V,    Z,  ENT,   \
-               LCTL, LGUI, LALT, RALT,  FN1, LSFT,  SPC,  FN2, LEFT, DOWN,   UP, RGHT),
+  [0] = KEYMAP_GRID( ESC, SCLN, COMM,  DOT,    P,    Y,    F,    G,    C,    R,    L, BSPC,   \
+                     GRV,    A,    O,    E,    U,    I,    D,    H,    T,    N,    S, MINS,   \
+                     TAB, QUOT,    Q,    J,    K,    X,    B,    M,    W,    V,    Z,  ENT,   \
+                    LCTL, LGUI, LALT, RALT,  FN1, LSFT,  SPC,  FN2, LEFT, DOWN,   UP, RGHT),
 
   /* 1: lower (FN1) */
-  [1] = KEYMAP( F1,   F2,   F3,   F4,   F5,   F6,   F7,   F8,   F9,  F10,  F11,  F12,   \
-              FN17,    7,    5,    3,    1,    9,    0,    2,    4,    6,    8, FN18,   \
-              TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,  INS,   \
-              TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, HOME, PGDN, PGUP,  END),
+  [1] = KEYMAP_GRID( F1,   F2,   F3,   F4,   F5,   F6,   F7,   F8,   F9,  F10,  F11,  F12,   \
+                   FN17,    7,    5,    3,    1,    9,    0,    2,    4,    6,    8, FN18,   \
+                   TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS,  INS,   \
+                   TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, HOME, PGDN, PGUP,  END),
 
   /* 2: raise (FN2) */
-  [2] = KEYMAP(PAUS, FN19, FN20, FN21, TRNS, TRNS, TRNS, TRNS, FN22, FN23, FN24,  DEL,   \
-               FN10, SLSH, FN11, FN12, LBRC,  EQL, FN13, RBRC, FN14, FN15, BSLS, FN16,   \
-               TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, PSCR,   \
-               TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS),
+  [2] = KEYMAP_GRID(PAUS, FN19, FN20, FN21, TRNS, TRNS, TRNS, TRNS, FN22, FN23, FN24,  DEL,   \
+                    FN10, SLSH, FN11, FN12, LBRC,  EQL, FN13, RBRC, FN14, FN15, BSLS, FN16,   \
+                    TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, PSCR,   \
+                    TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS, TRNS),
 
 };
 


### PR DESCRIPTION
This adds better support for grid layouts, as users won't have to redefine the KEYMAP in the keymap_common header file.  I saw @nathanrosspowell already uses this, and I think it is a good idea.