### PR TITLE
fixed the macros for hard colemak

### DIFF
--- a/keyboard/planck/extended_keymaps/extended_keymap_joe.c
+++ b/keyboard/planck/extended_keymaps/extended_keymap_joe.c
@@ -1,16 +1,16 @@
 #include "extended_keymap_common.h"
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  [0] = { /* Joe soft Colemak */
-    {FUNC(3),  CM_Q,    CM_W,    CM_F,    CM_P,    CM_G,   CM_J,   CM_L,    CM_U,    CM_Y,    CM_SCLN, KC_MINS},
-    {KC_BSPC,  CM_A,    CM_R,    CM_S,    CM_T,    CM_D,   CM_H,   CM_N,    CM_E,    CM_I,    CM_O,    KC_ENT },
-    {FUNC(15), CM_Z,    CM_X,    CM_C,    CM_V,    CM_B,   CM_K,   CM_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_QUOT},
-    {KC_LCTL,  KC_LGUI, KC_LALT, KC_LSFT, FUNC(1), KC_SPC, KC_SPC, FUNC(2), KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT}
-  },
-  [1] = { /* Joe colemak */
+  [0] = { /* Joe colemak */
     {FUNC(3),  KC_Q,    KC_W,    KC_F,    KC_P,    KC_G,   KC_J,   KC_L,    KC_U,    KC_Y,    KC_SCLN, KC_MINS},
     {KC_BSPC,  KC_A,    KC_R,    KC_S,    KC_T,    KC_D,   KC_H,   KC_N,    KC_E,    KC_I,    KC_O,    KC_ENT },
     {FUNC(15), KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,   KC_K,   KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_QUOT},
+    {KC_LCTL,  KC_LGUI, KC_LALT, KC_LSFT, FUNC(1), KC_SPC, KC_SPC, FUNC(2), KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT}
+  },
+  [1] = { /* Joe soft Colemak */
+    {FUNC(3),  CM_Q,    CM_W,    CM_F,    CM_P,    CM_G,   CM_J,   CM_L,    CM_U,    CM_Y,    CM_SCLN, KC_MINS},
+    {KC_BSPC,  CM_A,    CM_R,    CM_S,    CM_T,    CM_D,   CM_H,   CM_N,    CM_E,    CM_I,    CM_O,    KC_ENT },
+    {FUNC(15), CM_Z,    CM_X,    CM_C,    CM_V,    CM_B,   CM_K,   CM_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_QUOT},
     {KC_LCTL,  KC_LGUI, KC_LALT, KC_LSFT, FUNC(1), KC_SPC, KC_SPC, FUNC(2), KC_LEFT, KC_DOWN, KC_UP,   KC_RGHT}
   },
   [2] = { /* Joe NUMPAD */
@@ -72,17 +72,17 @@ const macro_t *action_get_macro(keyrecord_t *record, uint8_t id, uint8_t opt)
 {
     switch (id) {
         case M_Q0:
-            /* :( */
-            return MACRODOWN( D(LSFT), T(CM_SCLN), T(0), U(LSFT), END );
-        case M_Q1:
             /* :) */
-            return MACRODOWN( D(LSFT), T(CM_SCLN), T(9), U(LSFT), END );
+            return MACRODOWN( DOWN(KC_LSFT), TYPE(KC_SCLN), TYPE(KC_0), UP(KC_LSFT), END );
+        case M_Q1:
+            /* :( */
+            return MACRODOWN( DOWN(KC_LSFT), TYPE(KC_SCLN), TYPE(KC_9), UP(KC_LSFT), END );
         case M_Q2:
             /* (: | :) */
-            return MACRODOWN( D(LSFT), T(9), T(CM_SCLN), T(SPC), T(SPC), T(CM_SCLN), T(0), U(LSFT), T(LEFT), T(LEFT), T(LEFT), END );
+            return MACRODOWN( DOWN(KC_LSFT), TYPE(KC_9), TYPE(KC_SCLN), TYPE(KC_SPC), TYPE(KC_SPC), TYPE(KC_SCLN), TYPE(KC_0), UP(KC_LSFT), TYPE(KC_LEFT), TYPE(KC_LEFT), TYPE(KC_LEFT), END );
         case M_Q3:
             /* :( | ): */
-            return MACRODOWN( D(LSFT), T(CM_SCLN), T(9), T(SPC), T(SPC), T(0), T(CM_SCLN), U(LSFT), T(LEFT), T(LEFT), T(LEFT), END );
+            return MACRODOWN( DOWN(KC_LSFT), TYPE(KC_SCLN), TYPE(KC_9), TYPE(KC_SPC), TYPE(KC_SPC), TYPE(KC_0), TYPE(KC_SCLN), UP(KC_LSFT), TYPE(KC_LEFT), TYPE(KC_LEFT), TYPE(KC_LEFT), END );
         default:
             break;
     }


### PR DESCRIPTION
Rearranged the default, fixed the usage of CM_* constants, and changed the macro calls to the long form which doesn't assume the KC_ prefix.