### PR TITLE
Fixed brightness control; Reduced number of brightness levels to 4.

### DIFF
--- a/keyboard/planck/backlight.c
+++ b/keyboard/planck/backlight.c
@@ -36,14 +36,26 @@ void backlight_set(uint8_t level)
     {
         // Turn off PWM control on PB7, revert to output low.
         TCCR1A &= ~(_BV(COM1C1));
-        // CHANNEL = level << OFFSET | 0x0FFF;
-        CHANNEL = ((1 << level) - 1);
+        CHANNEL = 0x0;
+        // Prevent backlight blink on lowest level
+        PORTB &= ~(_BV(PORTB7));
     }
-    else
+    else if ( level == BACKLIGHT_LEVELS )
     {
+        // Prevent backlight blink on lowest level
+        PORTB &= ~(_BV(PORTB7));
         // Turn on PWM control of PB7
         TCCR1A |= _BV(COM1C1);
-        // CHANNEL = level << OFFSET | 0x0FFF;
-        CHANNEL = ((1 << level) - 1);
+        // Set the brightness
+        CHANNEL = 0xFFFF;
+    }
+    else        
+    {
+        // Prevent backlight blink on lowest level
+        PORTB &= ~(_BV(PORTB7));
+        // Turn on PWM control of PB7
+        TCCR1A |= _BV(COM1C1);
+        // Set the brightness
+        CHANNEL = 0xFFFF >> ((BACKLIGHT_LEVELS - level) * ((BACKLIGHT_LEVELS + 1) / 2));
     }
 }

--- a/keyboard/planck/config.h
+++ b/keyboard/planck/config.h
@@ -35,8 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //#define MATRIX_HAS_GHOST
 
 /* number of backlight levels */
-/* NOTE: this is the max value of 0..BACKLIGHT_LEVELS so really 16 levels. */
-#define BACKLIGHT_LEVELS 15
+#define BACKLIGHT_LEVELS 3
 
 /* Set 0 if debouncing isn't needed */
 #define DEBOUNCE    5
@@ -51,18 +50,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     keyboard_report->mods == (MOD_BIT(KC_LSHIFT) | MOD_BIT(KC_RSHIFT)) \
 )
 
-
-
 /*
  * Feature disable options
  *  These options are also useful to firmware size reduction.
  */
 
 /* disable debug print */
-//#define NO_DEBUG
+#define NO_DEBUG
 
 /* disable print */
-//#define NO_PRINT
+#define NO_PRINT
 
 /* disable action features */
 //#define NO_ACTION_LAYER


### PR DESCRIPTION
I've reduced the number of brightness levels to 4 (16 is a bit much) and changed the way brightness PWM is calculated.

Originally, at max brightness, it was actually at half brightness (2^15 = 32768 instead of 65536) because you were simply shifting a 1 by 15 (1000000000000000). All the other levels were scaled accordingly. So i've instead used 2^16 as a starting point, and then it gets shifted RIGHT the more, the lower the level.

However, even that's not quite ideal, because the first levels are nearly useless, because perceived brightness isn't quite linear, so i've fudged it up a bit.

Bottom line, with these changes, max brightness truly is 100% PWM, while other levels are squished slightly towards the max instead of spaced linearly.