### PR TITLE
use preprocessor conditional on backlight initialization

### DIFF
--- a/keyboard/planck/Makefile
+++ b/keyboard/planck/Makefile
@@ -126,7 +126,6 @@ COMMAND_ENABLE = yes    # Commands for debug and configuration
 # NKRO_ENABLE = yes		# USB Nkey Rollover - not yet supported in LUFA
 BACKLIGHT_ENABLE = yes  # Enable keyboard backlight functionality
 MIDI_ENABLE = YES 		# MIDI controls
-BACKLIGHT_ENABLE = yes
 
 ifdef MIDI_ENABLE
 	SRC += keymap_midi.c

--- a/keyboard/planck/matrix.c
+++ b/keyboard/planck/matrix.c
@@ -65,7 +65,9 @@ void matrix_init(void)
     MCUCR |= (1<<JTD);
     MCUCR |= (1<<JTD);
 
+    #if BACKLIGHT_ENABLE == 'yes'
     backlight_init_ports();
+    #endif
 
     // Turn status LED on
     DDRE |= (1<<6);


### PR DESCRIPTION
I didn't want to include backlight.h since it's not necessary for my build, but this requires nixing the backlight initialization from matrix.c. Seemed easy enough to just use the preprocessor to delete the line as necessary.